### PR TITLE
Upend advice about use of features

### DIFF
--- a/draft-ietf-git-using-github.md
+++ b/draft-ietf-git-using-github.md
@@ -235,9 +235,26 @@ recorded in a stable location other than the mailing list archive.  This also
 makes Working Group policies available to casual contributors who might only
 interact with the GitHub repository.
 
-GitHub prominently links to the CONTRIBUTING file on certain pages.  This file SHOULD
-be used in preference to the README for information that new contributors need.
-A link to the CONTRIBUTING file from the README is advised.
+GitHub prominently links to the CONTRIBUTING file on certain pages.  This file
+SHOULD be used in preference to the README for information that new contributors
+need.  A link to the CONTRIBUTING file from the README is advised.
+
+The set of GitHub features ({{features}}) that the Working Group relies upon
+need to be clearly documented in policies.  This document provides some guidance
+on potential policies and how those might be applied.
+
+Features that the Working Group does not rely upon SHOULD be made available to
+document editors.  Editors are then able to use these features for their own
+purposes.  For example, though the Working Group might not formally use issues
+to track items that require further discussion in order to reach consensus,
+keeping the issue tracker available to editors can be valuable.
+
+Working Group policies need to be set with the goal of improving transparency,
+participation, and ultimately the quality of the consensus behind documents.  At
+times, it might be appropriate to impose some limitations on what document
+editors are able to do in order to serve these goals.  Chairs SHOULD
+periodically consult with document editors to ensure that policies are effective
+and not unjustifiably constraining progress.
 
 
 ## Repositories

--- a/draft-ietf-git-using-github.md
+++ b/draft-ietf-git-using-github.md
@@ -217,12 +217,6 @@ Working Group Chairs have to decide what GitHub features the Working Group will
 rely upon.  {{features}} contains a more thorough discussion on the different
 features that can be used.
 
-Once a document is published in a repository on GitHub, many features like pull
-requests, issue tracking or the wiki can be individually disabled.  If specific
-features are not used by the Working Group in the development of the document,
-disabling those features avoids creating confusion in the wider community about
-what can be used.
-
 
 ## Working Group Policies
 


### PR DESCRIPTION
Two changes, two issues, but really this is the one idea.

The previous draft said that features not used could be disabled.  This is bad advice because that might be denying editors access to tools that would make their task easier.

The new advice says that editors can use features that the working group doesn't rely on.  It also says that chairs should consult editors to ensure that policies aren't adversely affecting them.